### PR TITLE
[ros2] declare specific boost depedencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED date_time math ramdom thread)
+find_package(Boost REQUIRED date_time random thread)
 
 include_directories(include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED date_time system thread)
+find_package(Boost REQUIRED date_time math ramdom thread)
 
 include_directories(include)
 

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-date-time-dev</build_depend>
-  <build_depend>libboost-math-dev</build_depend>
   <build_depend>libboost-random-dev</build_depend>
   <build_depend>libboost-thread-dev</build_depend>
 
@@ -27,7 +26,6 @@
   <build_export_depend>libboost-thread-dev</build_export_depend>
 
   <exec_depend>libboost-date-time</exec_depend>
-  <exec_depend>libboost-math</exec_depend>
   <exec_depend>libboost-random</exec_depend>
   <exec_depend>libboost-thread</exec_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -9,15 +9,27 @@
   The constructor of the wrapper is guaranteed to be thread safe and initialize its random number generator to a random seed.
   Seeds are obtained using a separate and different random number generator.
   </description>
-  <author email="isucan@willowgarage.edu">Ioan Sucan</author>
   <maintainer email="anasarrak@erlerobotics.com">Anas M'chichou</maintainer>
   <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/random_numbers</url>
+  <author email="isucan@willowgarage.edu">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>boost</build_depend>
-  <exec_depend>boost</exec_depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-date-time-dev</build_depend>
+  <build_depend>libboost-math-dev</build_depend>
+  <build_depend>libboost-random-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
+
+  <build_export_depend>libboost-dev</build_export_depend>
+  <build_export_depend>libboost-random-dev</build_export_depend>
+  <build_export_depend>libboost-thread-dev</build_export_depend>
+
+  <exec_depend>libboost-date-time</exec_depend>
+  <exec_depend>libboost-math</exec_depend>
+  <exec_depend>libboost-random</exec_depend>
+  <exec_depend>libboost-thread</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
In an effort to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.
This change saves ~600MB

Requires https://github.com/ros/rosdistro/pull/25995